### PR TITLE
Improve condition on interpolation substitution + add test

### DIFF
--- a/src/utils/interpolation.js
+++ b/src/utils/interpolation.js
@@ -56,23 +56,24 @@ class Interpolation {
       substitution = `{x${number}}`
     } else if(extraction.includes('id="INTERPOLATION"') && !extraction.includes('equiv-text=')) { // {x1} - May be converted later to {x} if only 1
       substitution = `{x1}`
-    } else if (extraction.includes('id="INTERPOLATION') && extraction.includes('equiv-text=')) {  // {name}, {variable}, {count}
+    } else if (extraction.includes('id="INTERPOLATION') && extraction.includes('equiv-text="{{') && extraction.includes('}}"')) { // {name}, {variable}, {count}
       name         = extraction.split('equiv-text="{{', 2)[1].split('}}"', 2)[0].trim()
       substitution = `{${name}}`
     } else if (extraction.includes('id="ICU')) {                                                  // {icu1}, {icu2}, ... - May be converted later to {icu} if only 1
       number       = (existingSubstitutions.join(" ").match(/{icu\d+?}/g) || []).length + 1
       substitution = `{icu${number}}`
-    } else if (HtmlTagExtraction.isOpeningTag(extraction)) {                                       // <tag>
+    } else if (HtmlTagExtraction.isOpeningTag(extraction)) {                                      // <tag>
       number       = HtmlTagExtraction.addToStackAndGetNumber(extraction)
       substitution = `&lt;${number}&gt;`
-    } else if (HtmlTagExtraction.isClosingTag(extraction)) {                                       // </tag>
+    } else if (HtmlTagExtraction.isClosingTag(extraction)) {                                      // </tag>
       number       = HtmlTagExtraction.removeFromStackAndGetNumber(extraction)
       substitution = `&lt;/${number}&gt;`
-    } else if (HtmlTagExtraction.isSelfClosingTag(extraction)) {                                   // <tag/>
+    } else if (HtmlTagExtraction.isSelfClosingTag(extraction)) {                                  // <tag/>
       number       = HtmlTagExtraction.addToStackAndGetNumber(extraction)
       substitution = `&lt;${number}/&gt;`
     } else {
-      console.error(`No substitution found for this extraction: ${extraction}`)
+      substitution = `{parsingError}`;
+      console.error(`\n⚠️ No substitution found for this extraction: ${extraction}\nPlease check the validity of your XLF formatting.`);
     }
 
     return substitution

--- a/tests/utils/interpolation.spec.js
+++ b/tests/utils/interpolation.spec.js
@@ -21,6 +21,11 @@ function escapeKeys(hash) {
   return hash
 }
 
+// Mock console.error
+let consoleErrorOutput = ""
+storeConsoleError = inputs => (consoleErrorOutput += inputs)
+console["error"] = jest.fn(storeConsoleError)
+
 /* Specs */
 
 describe('Interpolation.extract', () => {
@@ -437,5 +442,15 @@ describe('Interpolation.substitution', () => {
         ['{name}']
       )
     ).toEqual('{name}')
+  })
+
+  test('Simple example resulting in a "parsing error" when attempting a substitution (bad XLF formatting because of older version of extract-i18n)', () => {
+    expect(
+      Interpolation.substitution(
+        '<x id="INTERPOLATION" equiv-text="&lt;/a"/>',
+        []
+      )
+    ).toEqual('{parsingError}')
+    expect(consoleErrorOutput).toBe(`\n⚠️ No substitution found for this extraction: <x id="INTERPOLATION" equiv-text="&lt;/a"/>\nPlease check the validity of your XLF formatting.`);
   })
 })


### PR DESCRIPTION
To be considered valid, XLF interpolations that have an "id" attribute equal to "INTERPOLATION" and have an "equiv-text" attribute should have the value of their "equiv-text" attribute starting with double curly-braces: "{{".

If that is not the case, the substitution will fallback to "{{parsingError}}" and an error will be displayed in the console.