### PR TITLE
Handle placeholders (named or unnamed) in components

### DIFF
--- a/samples/expected-response.json
+++ b/samples/expected-response.json
@@ -193,6 +193,76 @@
       "references": [
         "src/app/app.component.html:46"
       ]
+    },
+    {
+      "source_id": "948d9a612c396e0de914ad0d8dc1b835a81dfdc16d4917cfa41bc0f1a0df9f0f",
+      "target_language": "fr",
+      "type": "source",
+      "source": "12. Variable interpolation: my name is {name}.",
+      "target": "12. Interpolation de variable : mon nom est {name}.",
+      "references": [
+        "src/app/app.component.html:48"
+      ]
+    },
+    {
+      "source_id": "b3a72447d25111fa4e48b739bcc4bdfaeb1e7bea70409bac9bcdf7f17992cea0",
+      "target_language": "fr",
+      "type": "source",
+      "source": "13. Named placeholder: {ITEMCOUNT} items.",
+      "target": "13. Placeholder nommé : {ITEMCOUNT} articles.",
+      "references": [
+        "src/app/app.component.html:50"
+      ]
+    },
+    {
+      "source_id": "f7dc4e90247945d0a9d70eccaafd75cb56c7987e3b1de3eaf970cd9673eb1cd0",
+      "target_language": "fr",
+      "type": "source",
+      "source": "Text to be translated",
+      "target": "Texte à traduire",
+      "references": [
+        "src/app/app.component.ts:17"
+      ]
+    },
+    {
+      "source_id": "eab068f292d85741ff602d3696392ca2a3d71df0343218eee35bf8d7d5258832",
+      "target_language": "fr",
+      "type": "source",
+      "source": "Hello {x}.",
+      "target": "Bonjour {x}.",
+      "references": [
+        "src/app/app.component.ts:18"
+      ]
+    },
+    {
+      "source_id": "22e4538560cea910c8552d1ce82c2ae67624e6230928af751878c47c58d3e0a9",
+      "target_language": "fr",
+      "type": "source",
+      "source": "You have two friends: {x1} & {x2}.",
+      "target": "Vous avez deux amis : {x1} et {x2}.",
+      "references": [
+        "src/app/app.component.ts:19"
+      ]
+    },
+    {
+      "source_id": "733ac8154b547bde5f8cb91c54b3f105f4da0e80cae74c56e69654630f3b46d8",
+      "target_language": "fr",
+      "type": "source",
+      "source": "There are {itemCount} items in your cart.",
+      "target": "Il y a {itemCount} articles dans votre panier.",
+      "references": [
+        "src/app/app.component.ts:20"
+      ]
+    },
+    {
+      "source_id": "6801d44c06148f6d7b411c863d7f803721c2d1931dc5b164b269b12da7f62a4f",
+      "target_language": "fr",
+      "type": "source",
+      "source": "Hello {x}. There are {itemCount} items in your cart.",
+      "target": "Bonjour {x}. Il y a {itemCount} articles dans votre panier.",
+      "references": [
+        "src/app/app.component.ts:21"
+      ]
     }
   ]
 }

--- a/samples/v12/src/app/app.component.html
+++ b/samples/v12/src/app/app.component.html
@@ -44,3 +44,7 @@
 <div i18n>10. A line break <br/> and all sorts <hr> of <hr/> horizontal <HR> rules,<hr style="display: none"/> even with attributes.</div>
 
 <p i18n>11. Symbols: < < && >> <1></p>
+
+<p i18n>12. Variable interpolation: my name is {{ name }}.</p>
+
+<p i18n>13. Named placeholder: {{ items.length // i18n(ph="itemCount") }} items.</p>

--- a/samples/v12/src/app/app.component.ts
+++ b/samples/v12/src/app/app.component.ts
@@ -9,6 +9,18 @@ export class AppComponent {
   gender = 'female';
   fly = true;
   logo = 'https://angular.io/assets/images/logos/angular/angular.png';
+  name = 'Bob';
+  friendNames = ['Patrick', 'Sandy'];
+  items = ['book', 'glass', 'lamp'];
+
+  localizedStrings = {
+    'simple':           $localize `Text to be translated`,
+    'onePlaceholder':   $localize `Hello ${this.name}.`,
+    'twoPlaceholders':  $localize `You have two friends: ${this.friendNames[0]} & ${this.friendNames[1]}.`,
+    'namedPlaceholder': $localize `There are ${this.items.length}:itemCount: items in your cart.`,
+    'combination':      $localize `Hello ${this.name}. There are ${this.items.length}:itemCount: items in your cart.`
+  };
+
   inc(i: number) {
     this.minutes = Math.min(5, Math.max(0, this.minutes + i));
   }

--- a/samples/v12/src/locale/messages.fr.xlf
+++ b/samples/v12/src/locale/messages.fr.xlf
@@ -171,6 +171,62 @@
         </context-group>
         <target>11. Des symboles : &lt; &lt; &amp;&amp; &gt;&gt; &lt;1&gt;</target>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <target>12. Interpolation de variable : mon nom est <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</target>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <target>13. Placeholder nommé : <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> articles.</target>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <target>Texte à traduire</target>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <target>Bonjour <x id="PH" equiv-text="this.name"/>.</target>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <target>Vous avez deux amis : <x id="PH" equiv-text="this.friendNames[0]"/> et <x id="PH_1" equiv-text="this.friendNames[1]"/>.</target>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <target>Il y a <x id="itemCount" equiv-text="this.items.length"/> articles dans votre panier.</target>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <target>Bonjour <x id="PH" equiv-text="this.name"/>. Il y a <x id="itemCount" equiv-text="this.items.length"/> articles dans votre panier.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/samples/v12/src/locale/messages.it.xlf
+++ b/samples/v12/src/locale/messages.it.xlf
@@ -168,6 +168,62 @@
         </context-group>
         <target></target>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/samples/v12/src/locale/messages.xlf
+++ b/samples/v12/src/locale/messages.xlf
@@ -150,6 +150,55 @@
           <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/samples/v13/src/app/app.component.html
+++ b/samples/v13/src/app/app.component.html
@@ -44,3 +44,7 @@
 <div i18n>10. A line break <br/> and all sorts <hr> of <hr/> horizontal <HR> rules,<hr style="display: none"/> even with attributes.</div>
 
 <p i18n>11. Symbols: < < && >> <1></p>
+
+<p i18n>12. Variable interpolation: my name is {{ name }}.</p>
+
+<p i18n>13. Named placeholder: {{ items.length // i18n(ph="itemCount") }} items.</p>

--- a/samples/v13/src/app/app.component.ts
+++ b/samples/v13/src/app/app.component.ts
@@ -9,6 +9,18 @@ export class AppComponent {
   gender = 'female';
   fly = true;
   logo = 'https://angular.io/assets/images/logos/angular/angular.png';
+  name = 'Bob';
+  friendNames = ['Patrick', 'Sandy'];
+  items = ['book', 'glass', 'lamp'];
+
+  localizedStrings = {
+    'simple':           $localize `Text to be translated`,
+    'onePlaceholder':   $localize `Hello ${this.name}.`,
+    'twoPlaceholders':  $localize `You have two friends: ${this.friendNames[0]} & ${this.friendNames[1]}.`,
+    'namedPlaceholder': $localize `There are ${this.items.length}:itemCount: items in your cart.`,
+    'combination':      $localize `Hello ${this.name}. There are ${this.items.length}:itemCount: items in your cart.`
+  };
+
   inc(i: number) {
     this.minutes = Math.min(5, Math.max(0, this.minutes + i));
   }

--- a/samples/v13/src/locale/messages.fr.xlf
+++ b/samples/v13/src/locale/messages.fr.xlf
@@ -171,6 +171,62 @@
         </context-group>
         <target>11. Des symboles : &lt; &lt; &amp;&amp; &gt;&gt; &lt;1&gt;</target>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <target>12. Interpolation de variable : mon nom est <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</target>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <target>13. Placeholder nommé : <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> articles.</target>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <target>Texte à traduire</target>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <target>Bonjour <x id="PH" equiv-text="this.name"/>.</target>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <target>Vous avez deux amis : <x id="PH" equiv-text="this.friendNames[0]"/> et <x id="PH_1" equiv-text="this.friendNames[1]"/>.</target>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <target>Il y a <x id="itemCount" equiv-text="this.items.length"/> articles dans votre panier.</target>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <target>Bonjour <x id="PH" equiv-text="this.name"/>. Il y a <x id="itemCount" equiv-text="this.items.length"/> articles dans votre panier.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/samples/v13/src/locale/messages.it.xlf
+++ b/samples/v13/src/locale/messages.it.xlf
@@ -168,6 +168,62 @@
         </context-group>
         <target></target>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/samples/v13/src/locale/messages.xlf
+++ b/samples/v13/src/locale/messages.xlf
@@ -150,6 +150,55 @@
           <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/samples/v14/src/app/app.component.html
+++ b/samples/v14/src/app/app.component.html
@@ -44,3 +44,7 @@
 <div i18n>10. A line break <br/> and all sorts <hr> of <hr/> horizontal <HR> rules,<hr style="display: none"/> even with attributes.</div>
 
 <p i18n>11. Symbols: < < && >> <1></p>
+
+<p i18n>12. Variable interpolation: my name is {{ name }}.</p>
+
+<p i18n>13. Named placeholder: {{ items.length // i18n(ph="itemCount") }} items.</p>

--- a/samples/v14/src/app/app.component.ts
+++ b/samples/v14/src/app/app.component.ts
@@ -9,6 +9,18 @@ export class AppComponent {
   gender = 'female';
   fly = true;
   logo = 'https://angular.io/assets/images/logos/angular/angular.png';
+  name = 'Bob';
+  friendNames = ['Patrick', 'Sandy'];
+  items = ['book', 'glass', 'lamp'];
+
+  localizedStrings = {
+    'simple':           $localize `Text to be translated`,
+    'onePlaceholder':   $localize `Hello ${this.name}.`,
+    'twoPlaceholders':  $localize `You have two friends: ${this.friendNames[0]} & ${this.friendNames[1]}.`,
+    'namedPlaceholder': $localize `There are ${this.items.length}:itemCount: items in your cart.`,
+    'combination':      $localize `Hello ${this.name}. There are ${this.items.length}:itemCount: items in your cart.`
+  };
+
   inc(i: number) {
     this.minutes = Math.min(5, Math.max(0, this.minutes + i));
   }

--- a/samples/v14/src/locale/messages.fr.xlf
+++ b/samples/v14/src/locale/messages.fr.xlf
@@ -171,6 +171,62 @@
         </context-group>
         <target>11. Des symboles : &lt; &lt; &amp;&amp; &gt;&gt; &lt;1&gt;</target>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <target>12. Interpolation de variable : mon nom est <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</target>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <target>13. Placeholder nommé : <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> articles.</target>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <target>Texte à traduire</target>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <target>Bonjour <x id="PH" equiv-text="this.name"/>.</target>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <target>Vous avez deux amis : <x id="PH" equiv-text="this.friendNames[0]"/> et <x id="PH_1" equiv-text="this.friendNames[1]"/>.</target>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <target>Il y a <x id="itemCount" equiv-text="this.items.length"/> articles dans votre panier.</target>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <target>Bonjour <x id="PH" equiv-text="this.name"/>. Il y a <x id="itemCount" equiv-text="this.items.length"/> articles dans votre panier.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/samples/v14/src/locale/messages.it.xlf
+++ b/samples/v14/src/locale/messages.it.xlf
@@ -168,6 +168,62 @@
         </context-group>
         <target></target>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+        <target></target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/samples/v14/src/locale/messages.xlf
+++ b/samples/v14/src/locale/messages.xlf
@@ -150,6 +150,55 @@
           <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7789534275794595013" datatype="html">
+        <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5008943336610818013" datatype="html">
+        <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6962731021804310323" datatype="html">
+        <source>Text to be translated</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="28113302887959640" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6983233377181567851" datatype="html">
+        <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8967721153468652541" datatype="html">
+        <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3663231730977935317" datatype="html">
+        <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/app.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/tests/utils/interpolation.spec.js
+++ b/tests/utils/interpolation.spec.js
@@ -444,6 +444,42 @@ describe('Interpolation.substitution', () => {
     ).toEqual('{name}')
   })
 
+  test('Simple example with a single unnamed placeholder, when using $localize in a component', () => {
+    expect(
+      Interpolation.substitution(
+        '<x id="PH" equiv-text="this.name"/>',
+        []
+      )
+    ).toEqual('{x1}')
+  })
+
+  test('Simple example with indexed, unnamed placeholders, when using $localize in a component', () => {
+    expect(
+      Interpolation.substitution(
+        '<x id="PH_1" equiv-text="this.otherName"/>',
+        ['{x1}']
+      )
+    ).toEqual('{x2}')
+  })
+
+  test('Simple example with a named placeholder, when using $localize in a component', () => {
+    expect(
+      Interpolation.substitution(
+        '<x id="itemCount" equiv-text="this.items.length"/>',
+        []
+      )
+    ).toEqual('{itemCount}')
+  })
+
+  test('Simple example with a named placeholder, when using $localize in a component', () => {
+    expect(
+      Interpolation.substitution(
+        '<x id="itemCount" equiv-text="this.items.length"/>',
+        []
+      )
+    ).toEqual('{itemCount}')
+  })
+
   test('Simple example resulting in a "parsing error" when attempting a substitution (bad XLF formatting because of older version of extract-i18n)', () => {
     expect(
       Interpolation.substitution(

--- a/tests/utils/interpolation.spec.js
+++ b/tests/utils/interpolation.spec.js
@@ -471,15 +471,6 @@ describe('Interpolation.substitution', () => {
     ).toEqual('{itemCount}')
   })
 
-  test('Simple example with a named placeholder, when using $localize in a component', () => {
-    expect(
-      Interpolation.substitution(
-        '<x id="itemCount" equiv-text="this.items.length"/>',
-        []
-      )
-    ).toEqual('{itemCount}')
-  })
-
   test('Simple example resulting in a "parsing error" when attempting a substitution (bad XLF formatting because of older version of extract-i18n)', () => {
     expect(
       Interpolation.substitution(


### PR DESCRIPTION
Updated the `substitution()` method in the `interpolation.js` file to handle placeholders (equivalent of interpolations when using the `$localize` syntax in component classes).

These placeholders can be:
- unnamed: in which case, the extraction from the XLF file will contain `<x id="PH`
- named: in which case, the name will be used as the id in the extraction from the XLF file (see "naming placeholders" in [documentation](https://next.angular.io/api/localize/init/$localize))

Updated the examples in the v14, v13 and v12 samples, as well as the expected json response for the spec tests of these samples.

Added tests for the newly handled interpolation substitutions.