### PR TITLE
Don't write empty `<target>` in translated XLF

### DIFF
--- a/samples/v06/src/locale/messages.it.xlf
+++ b/samples/v06/src/locale/messages.it.xlf
@@ -11,7 +11,6 @@
         </context-group>
         <note priority="1" from="description">An introduction header for this sample</note>
         <note priority="1" from="meaning">User welcome</note>
-        <target></target>
       </trans-unit>
       <trans-unit id="ba0cc104d3d69bf669f97b8d96a4c5d8d9559aa3" datatype="html">
         <source>I don&apos;t output any element</source>
@@ -19,7 +18,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="701174153757adf13e7c24a248c8a873ac9f5193" datatype="html">
         <source>Angular logo</source>
@@ -27,7 +25,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">10</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="d69f6b42305f49332026fef24b40227f02e34594" datatype="html">
         <source>Updated <x id="ICU" equiv-text="{minutes, plural, =0 {...} =1 {...} other {...}}"/></source>
@@ -35,7 +32,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5a134dee893586d02bffc9611056b9cadf9abfad" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {just now} =1 {one minute ago} other {<x id="INTERPOLATION" equiv-text="{{minutes}}"/> minutes ago} }</source>
@@ -43,7 +39,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="f99f34ac9bd4606345071bd813858dec29f3b7d1" datatype="html">
         <source>The author is <x id="ICU" equiv-text="{gender, select, male {...} female {...} other {...}}"/></source>
@@ -51,7 +46,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="eff74b75ab7364b6fa888f1cbfae901aaaf02295" datatype="html">
         <source>{VAR_SELECT, select, male {male} female {female} other {other} }</source>
@@ -59,7 +53,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="972cb0cf3e442f7b1c00d7dab168ac08d6bdf20c" datatype="html">
         <source>Updated: <x id="ICU" equiv-text="{minutes, plural, =0 {...} =1 {...} other {...}}"/>
@@ -68,7 +61,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7151c2e67748b726f0864fc443861d45df21d706" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {just now} =1 {one minute ago} other {<x id="INTERPOLATION" equiv-text="{{minutes}}"/> minutes ago by {VAR_SELECT, select, male {male} female {female} other {other} }} }</source>
@@ -76,7 +68,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="e915e7ac543c79724c2bf74c0ad40fea0b3e5e63" datatype="html">
         <source>01. A simple <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>tag<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> interpolation.</source>
@@ -84,7 +75,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="a6b7adfc74f9a2bceadc32f30d3f43bdd620d77e" datatype="html">
         <source>02. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>interpolations<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>.</source>
@@ -92,7 +82,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5b77d25c5e97e6fd0a23b22357d2bf42c4cf4e91" datatype="html">
         <source>03. A <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>series <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>of <x id="START_SMALL_TEXT" ctype="x-small" equiv-text="&lt;small&gt;"/>nested<x id="CLOSE_SMALL_TEXT" ctype="x-small" equiv-text="&lt;/small&gt;"/> tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -100,7 +89,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">30</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="ee033750acfa968012ce6a97af3282e590658dc6" datatype="html">
         <source>04. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag interpolations <x id="START_EMPHASISED_TEXT_1" ctype="x-em" equiv-text="&lt;em&gt;"/>with attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -108,7 +96,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">32</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7ad2c4ad8cd2978acd5e642c3825530e7ee7b7d7" datatype="html">
         <source>05. A series of <x id="START_EMPHASISED_TEXT_1" ctype="x-em" equiv-text="&lt;em&gt;"/>nested <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>with<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -116,7 +103,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="e254fe917a986981f53455738a4471eec1505735" datatype="html">
         <source>06. An example of <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>link<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> with many attributes.</source>
@@ -124,7 +110,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">36</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="4938abcf92f512c4a8a7946fc8952e4c8f1888bc" datatype="html">
         <source>07. Opening a <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>tag and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>opening it again<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> before closing it<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> and closing it again (strong tag).</source>
@@ -132,7 +117,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">38</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="98d4f079e9742d8508131f870c6255add6f9cae7" datatype="html">
         <source>08. All <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> sorts <x id="LINE_BREAK_1" ctype="lb" equiv-text="&lt;BR/&gt;"/> of <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> line <x id="LINE_BREAK_2" ctype="lb" equiv-text="&lt;Br/&gt;"/> breaks <x id="LINE_BREAK_1" ctype="lb" equiv-text="&lt;BR/&gt;"/>.</source>
@@ -140,7 +124,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">40</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="08e3dcdecc5eef5118a97db2dabefc93d6f20da9" datatype="html">
         <source>09. <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>We have nested interpolations and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>a line<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> break<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> in-between<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -148,7 +131,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="80a7e4c299accb175b891ff3ff839f2a8c33ee31" datatype="html">
         <source>10. A line break <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> and all sorts <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> of <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> horizontal <x id="HORIZONTAL_RULE_1" ctype="x-HR" equiv-text="&lt;HR/&gt;"/> rules,<x id="HORIZONTAL_RULE_2" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> even with attributes.</source>
@@ -156,7 +138,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">44</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="1d84cdff299c08bc716a7139686e68f20dde962c" datatype="html">
         <source>11. Symbols: &lt; &lt; &amp;&amp; &gt;&gt; &lt;1&gt;</source>
@@ -164,7 +145,6 @@
           <context context-type="sourcefile">app/app.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
-        <target></target>
       </trans-unit>
     </body>
   </file>

--- a/samples/v09/src/locale/messages.it.xlf
+++ b/samples/v09/src/locale/messages.it.xlf
@@ -11,7 +11,6 @@
         </context-group>
         <note priority="1" from="description">An introduction header for this sample</note>
         <note priority="1" from="meaning">User welcome</note>
-        <target></target>
       </trans-unit>
       <trans-unit id="ba0cc104d3d69bf669f97b8d96a4c5d8d9559aa3" datatype="html">
         <source>I don&apos;t output any element</source>
@@ -19,7 +18,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="701174153757adf13e7c24a248c8a873ac9f5193" datatype="html">
         <source>Angular logo</source>
@@ -27,7 +25,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">10</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="d69f6b42305f49332026fef24b40227f02e34594" datatype="html">
         <source>Updated <x id="ICU" equiv-text="{minutes, plural, =0 {...} =1 {...} other {...}}"/></source>
@@ -35,7 +32,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5a134dee893586d02bffc9611056b9cadf9abfad" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {just now} =1 {one minute ago} other {<x id="INTERPOLATION" equiv-text="{{minutes}}"/> minutes ago} }</source>
@@ -47,7 +43,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="f99f34ac9bd4606345071bd813858dec29f3b7d1" datatype="html">
         <source>The author is <x id="ICU" equiv-text="{gender, select, male {...} female {...} other {...}}"/></source>
@@ -55,7 +50,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="eff74b75ab7364b6fa888f1cbfae901aaaf02295" datatype="html">
         <source>{VAR_SELECT, select, male {male} female {female} other {other} }</source>
@@ -67,7 +61,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">22</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="807dbdf564e4c92a97060985bfd00530f8b275d9" datatype="html">
         <source>Updated: <x id="ICU" equiv-text="{minutes, plural, =0 {...} =1 {...} other {...}}"/> by <x id="ICU_1" equiv-text="{gender, select, male {...} female {...} other {...}}"/>
@@ -76,7 +69,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="e915e7ac543c79724c2bf74c0ad40fea0b3e5e63" datatype="html">
         <source>01. A simple <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>tag<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> interpolation.</source>
@@ -84,7 +76,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="a6b7adfc74f9a2bceadc32f30d3f43bdd620d77e" datatype="html">
         <source>02. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>interpolations<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>.</source>
@@ -92,7 +83,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5b77d25c5e97e6fd0a23b22357d2bf42c4cf4e91" datatype="html">
         <source>03. A <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>series <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>of <x id="START_SMALL_TEXT" ctype="x-small" equiv-text="&lt;small&gt;"/>nested<x id="CLOSE_SMALL_TEXT" ctype="x-small" equiv-text="&lt;/small&gt;"/> tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -100,7 +90,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">30</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="ee033750acfa968012ce6a97af3282e590658dc6" datatype="html">
         <source>04. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag interpolations <x id="START_EMPHASISED_TEXT_1" ctype="x-em" equiv-text="&lt;em&gt;"/>with attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -108,7 +97,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">32</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7ad2c4ad8cd2978acd5e642c3825530e7ee7b7d7" datatype="html">
         <source>05. A series of <x id="START_EMPHASISED_TEXT_1" ctype="x-em" equiv-text="&lt;em&gt;"/>nested <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>with<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -116,7 +104,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="e254fe917a986981f53455738a4471eec1505735" datatype="html">
         <source>06. An example of <x id="START_LINK" ctype="x-a" equiv-text="&lt;a&gt;"/>link<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> with many attributes.</source>
@@ -124,7 +111,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">36</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="4938abcf92f512c4a8a7946fc8952e4c8f1888bc" datatype="html">
         <source>07. Opening a <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>tag and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>opening it again<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> before closing it<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> and closing it again (strong tag).</source>
@@ -132,7 +118,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">38</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="98d4f079e9742d8508131f870c6255add6f9cae7" datatype="html">
         <source>08. All <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> sorts <x id="LINE_BREAK_1" ctype="lb" equiv-text="&lt;BR/&gt;"/> of <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> line <x id="LINE_BREAK_2" ctype="lb" equiv-text="&lt;Br/&gt;"/> breaks <x id="LINE_BREAK_1" ctype="lb" equiv-text="&lt;BR/&gt;"/>.</source>
@@ -140,7 +125,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">40</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="08e3dcdecc5eef5118a97db2dabefc93d6f20da9" datatype="html">
         <source>09. <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>We have nested interpolations and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>a line<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> break<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> in-between<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -148,7 +132,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="80a7e4c299accb175b891ff3ff839f2a8c33ee31" datatype="html">
         <source>10. A line break <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> and all sorts <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> of <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> horizontal <x id="HORIZONTAL_RULE_1" ctype="x-HR" equiv-text="&lt;HR/&gt;"/> rules,<x id="HORIZONTAL_RULE_2" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> even with attributes.</source>
@@ -156,7 +139,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">44</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="1d84cdff299c08bc716a7139686e68f20dde962c" datatype="html">
         <source>11. Symbols: &lt; &lt; &amp;&amp; &gt;&gt; &lt;1&gt;</source>
@@ -164,7 +146,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
-        <target></target>
       </trans-unit>
     </body>
   </file>

--- a/samples/v12/src/locale/messages.it.xlf
+++ b/samples/v12/src/locale/messages.it.xlf
@@ -10,7 +10,6 @@
         </context-group>
         <note priority="1" from="description">An introduction header for this sample</note>
         <note priority="1" from="meaning">User welcome</note>
-        <target></target>
       </trans-unit>
       <trans-unit id="5206857922697139278" datatype="html">
         <source>I don&apos;t output any element</source>
@@ -18,7 +17,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="392942015236586892" datatype="html">
         <source>Angular logo</source>
@@ -26,7 +24,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">10</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="4606963464835766483" datatype="html">
         <source>Updated <x id="ICU" equiv-text="{minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}"/></source>
@@ -34,7 +31,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2002272803511843863" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {just now} =1 {one minute ago} other {<x id="INTERPOLATION"/> minutes ago}}</source>
@@ -46,7 +42,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">19,22</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="3560311772637911677" datatype="html">
         <source>The author is <x id="ICU" equiv-text="{gender, select, male {male} female {female} other {other}}"/></source>
@@ -54,7 +49,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7670372064920373295" datatype="html">
         <source>{VAR_SELECT, select, male {male} female {female} other {other}}</source>
@@ -66,7 +60,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">22</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6056512605726495811" datatype="html">
         <source>Updated: <x id="ICU" equiv-text="{minutes, plural,
@@ -78,7 +71,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">19,23</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6614439584127246414" datatype="html">
         <source>01. A simple <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>tag<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> interpolation.</source>
@@ -86,7 +78,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="921899479087148151" datatype="html">
         <source>02. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>interpolations<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>.</source>
@@ -94,7 +85,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="1025114103596514402" datatype="html">
         <source>03. A <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>series <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>of <x id="START_SMALL_TEXT" ctype="x-small" equiv-text="&lt;small&gt;"/>nested<x id="CLOSE_SMALL_TEXT" ctype="x-small" equiv-text="&lt;/small&gt;"/> tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -102,7 +92,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">30</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2158469501470947762" datatype="html">
         <source>04. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag interpolations <x id="START_EMPHASISED_TEXT_1" equiv-text="&lt;em style=&quot;color:red&quot;&gt;"/>with attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -110,7 +99,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">32</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5333372789835402443" datatype="html">
         <source>05. A series of <x id="START_EMPHASISED_TEXT_1" equiv-text="&lt;em style=&quot;color:green&quot;&gt;"/>nested <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong data-id=&quot;42&quot;&gt;"/>tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em style=&quot;color:red&quot;&gt;"/>with<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -118,7 +106,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8880256692345672869" datatype="html">
         <source>06. An example of <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;http://google.com&quot; target=&quot;_blank&quot; data-id=&quot;5324532&quot; title=&quot;Let&apos;s use symbols #&amp; &lt;@ &gt;&gt; %;&quot;&gt;"/>link<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> with many attributes.</source>
@@ -126,7 +113,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">36</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2602478720328613603" datatype="html">
         <source>07. Opening a <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>tag and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>opening it again<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> before closing it<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> and closing it again (strong tag).</source>
@@ -134,7 +120,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">38</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8102224577822467593" datatype="html">
         <source>08. All <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> sorts <x id="LINE_BREAK_1" equiv-text="&lt;BR/&gt;"/> of <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> line <x id="LINE_BREAK_2" equiv-text="&lt;Br /&gt;"/> breaks <x id="LINE_BREAK_1" equiv-text="&lt;BR/&gt;"/>.</source>
@@ -142,7 +127,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">40</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8048158107145255945" datatype="html">
         <source>09. <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>We have nested interpolations and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>a line<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> break<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> in-between<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -150,7 +134,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="1162418464075294573" datatype="html">
         <source>10. A line break <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> and all sorts <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> of <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> horizontal <x id="HORIZONTAL_RULE_1" equiv-text="&lt;HR&gt;"/> rules,<x id="HORIZONTAL_RULE_2" equiv-text="&lt;hr style=&quot;display: none&quot;/&gt;"/> even with attributes.</source>
@@ -158,7 +141,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">44</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="9075420308171641266" datatype="html">
         <source>11. Symbols: &lt; &lt; &amp;&amp; &gt;&gt; &lt;1&gt;</source>
@@ -166,7 +148,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7789534275794595013" datatype="html">
         <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
@@ -174,7 +155,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">48</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5008943336610818013" datatype="html">
         <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
@@ -182,7 +162,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">50</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6962731021804310323" datatype="html">
         <source>Text to be translated</source>
@@ -190,7 +169,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="28113302887959640" datatype="html">
         <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
@@ -198,7 +176,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6983233377181567851" datatype="html">
         <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
@@ -206,7 +183,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8967721153468652541" datatype="html">
         <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
@@ -214,7 +190,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">20</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="3663231730977935317" datatype="html">
         <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
@@ -222,7 +197,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">21</context>
         </context-group>
-        <target></target>
       </trans-unit>
     </body>
   </file>

--- a/samples/v13/src/locale/messages.it.xlf
+++ b/samples/v13/src/locale/messages.it.xlf
@@ -10,7 +10,6 @@
         </context-group>
         <note priority="1" from="description">An introduction header for this sample</note>
         <note priority="1" from="meaning">User welcome</note>
-        <target></target>
       </trans-unit>
       <trans-unit id="5206857922697139278" datatype="html">
         <source>I don&apos;t output any element</source>
@@ -18,7 +17,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="392942015236586892" datatype="html">
         <source>Angular logo</source>
@@ -26,7 +24,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">10</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="4606963464835766483" datatype="html">
         <source>Updated <x id="ICU" equiv-text="{minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}" xid="1887283401472369100"/></source>
@@ -34,7 +31,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2002272803511843863" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {just now} =1 {one minute ago} other {<x id="INTERPOLATION"/> minutes ago}}</source>
@@ -46,7 +42,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">19,22</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="3560311772637911677" datatype="html">
         <source>The author is <x id="ICU" equiv-text="{gender, select, male {male} female {female} other {other}}" xid="7670372064920373295"/></source>
@@ -54,7 +49,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7670372064920373295" datatype="html">
         <source>{VAR_SELECT, select, male {male} female {female} other {other}}</source>
@@ -66,7 +60,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">22</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6056512605726495811" datatype="html">
         <source>Updated: <x id="ICU" equiv-text="{minutes, plural,
@@ -78,7 +71,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">19,23</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6614439584127246414" datatype="html">
         <source>01. A simple <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>tag<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> interpolation.</source>
@@ -86,7 +78,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="921899479087148151" datatype="html">
         <source>02. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>interpolations<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>.</source>
@@ -94,7 +85,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="1025114103596514402" datatype="html">
         <source>03. A <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>series <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>of <x id="START_SMALL_TEXT" ctype="x-small" equiv-text="&lt;small&gt;"/>nested<x id="CLOSE_SMALL_TEXT" ctype="x-small" equiv-text="&lt;/small&gt;"/> tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -102,7 +92,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">30</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2158469501470947762" datatype="html">
         <source>04. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag interpolations <x id="START_EMPHASISED_TEXT_1" equiv-text="&lt;em style=&quot;color:red&quot;&gt;"/>with attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -110,7 +99,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">32</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5333372789835402443" datatype="html">
         <source>05. A series of <x id="START_EMPHASISED_TEXT_1" equiv-text="&lt;em style=&quot;color:green&quot;&gt;"/>nested <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong data-id=&quot;42&quot;&gt;"/>tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em style=&quot;color:red&quot;&gt;"/>with<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -118,7 +106,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8880256692345672869" datatype="html">
         <source>06. An example of <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;http://google.com&quot; target=&quot;_blank&quot; data-id=&quot;5324532&quot; title=&quot;Let&apos;s use symbols #&amp; &lt;@ &gt;&gt; %;&quot;&gt;"/>link<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> with many attributes.</source>
@@ -126,7 +113,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">36</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2602478720328613603" datatype="html">
         <source>07. Opening a <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>tag and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>opening it again<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> before closing it<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> and closing it again (strong tag).</source>
@@ -134,7 +120,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">38</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8102224577822467593" datatype="html">
         <source>08. All <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> sorts <x id="LINE_BREAK_1" equiv-text="&lt;BR/&gt;"/> of <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> line <x id="LINE_BREAK_2" equiv-text="&lt;Br /&gt;"/> breaks <x id="LINE_BREAK_1" equiv-text="&lt;BR/&gt;"/>.</source>
@@ -142,7 +127,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">40</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8048158107145255945" datatype="html">
         <source>09. <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>We have nested interpolations and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>a line<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> break<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> in-between<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -150,7 +134,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="1162418464075294573" datatype="html">
         <source>10. A line break <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> and all sorts <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> of <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> horizontal <x id="HORIZONTAL_RULE_1" equiv-text="&lt;HR&gt;"/> rules,<x id="HORIZONTAL_RULE_2" equiv-text="&lt;hr style=&quot;display: none&quot;/&gt;"/> even with attributes.</source>
@@ -158,7 +141,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">44</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="9075420308171641266" datatype="html">
         <source>11. Symbols: &lt; &lt; &amp;&amp; &gt;&gt; &lt;1&gt;</source>
@@ -166,7 +148,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7789534275794595013" datatype="html">
         <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
@@ -174,7 +155,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">48</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5008943336610818013" datatype="html">
         <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
@@ -182,7 +162,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">50</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6962731021804310323" datatype="html">
         <source>Text to be translated</source>
@@ -190,7 +169,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="28113302887959640" datatype="html">
         <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
@@ -198,7 +176,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6983233377181567851" datatype="html">
         <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
@@ -206,7 +183,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8967721153468652541" datatype="html">
         <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
@@ -214,7 +190,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">20</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="3663231730977935317" datatype="html">
         <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
@@ -222,7 +197,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">21</context>
         </context-group>
-        <target></target>
       </trans-unit>
     </body>
   </file>

--- a/samples/v14/src/locale/messages.it.xlf
+++ b/samples/v14/src/locale/messages.it.xlf
@@ -10,7 +10,6 @@
         </context-group>
         <note priority="1" from="description">An introduction header for this sample</note>
         <note priority="1" from="meaning">User welcome</note>
-        <target></target>
       </trans-unit>
       <trans-unit id="5206857922697139278" datatype="html">
         <source>I don&apos;t output any element</source>
@@ -18,7 +17,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">6</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="392942015236586892" datatype="html">
         <source>Angular logo</source>
@@ -26,7 +24,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">10</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="4606963464835766483" datatype="html">
         <source>Updated <x id="ICU" equiv-text="{minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}" xid="1887283401472369100"/></source>
@@ -34,7 +31,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2002272803511843863" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {just now} =1 {one minute ago} other {<x id="INTERPOLATION"/> minutes ago}}</source>
@@ -46,7 +42,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">19,22</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="3560311772637911677" datatype="html">
         <source>The author is <x id="ICU" equiv-text="{gender, select, male {male} female {female} other {other}}" xid="7670372064920373295"/></source>
@@ -54,7 +49,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7670372064920373295" datatype="html">
         <source>{VAR_SELECT, select, male {male} female {female} other {other}}</source>
@@ -66,7 +60,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">22</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6056512605726495811" datatype="html">
         <source>Updated: <x id="ICU" equiv-text="{minutes, plural,
@@ -78,7 +71,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">19,23</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6614439584127246414" datatype="html">
         <source>01. A simple <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>tag<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> interpolation.</source>
@@ -86,7 +78,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">26</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="921899479087148151" datatype="html">
         <source>02. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>interpolations<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/>.</source>
@@ -94,7 +85,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">28</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="1025114103596514402" datatype="html">
         <source>03. A <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>series <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>of <x id="START_SMALL_TEXT" ctype="x-small" equiv-text="&lt;small&gt;"/>nested<x id="CLOSE_SMALL_TEXT" ctype="x-small" equiv-text="&lt;/small&gt;"/> tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -102,7 +92,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">30</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2158469501470947762" datatype="html">
         <source>04. A series of <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>non-nested<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> tag interpolations <x id="START_EMPHASISED_TEXT_1" equiv-text="&lt;em style=&quot;color:red&quot;&gt;"/>with attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -110,7 +99,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">32</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5333372789835402443" datatype="html">
         <source>05. A series of <x id="START_EMPHASISED_TEXT_1" equiv-text="&lt;em style=&quot;color:green&quot;&gt;"/>nested <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong data-id=&quot;42&quot;&gt;"/>tag<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> interpolations <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em style=&quot;color:red&quot;&gt;"/>with<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/> attributes<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -118,7 +106,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">34</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8880256692345672869" datatype="html">
         <source>06. An example of <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;http://google.com&quot; target=&quot;_blank&quot; data-id=&quot;5324532&quot; title=&quot;Let&apos;s use symbols #&amp; &lt;@ &gt;&gt; %;&quot;&gt;"/>link<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> with many attributes.</source>
@@ -126,7 +113,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">36</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="2602478720328613603" datatype="html">
         <source>07. Opening a <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>tag and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>opening it again<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> before closing it<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> and closing it again (strong tag).</source>
@@ -134,7 +120,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">38</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8102224577822467593" datatype="html">
         <source>08. All <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> sorts <x id="LINE_BREAK_1" equiv-text="&lt;BR/&gt;"/> of <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> line <x id="LINE_BREAK_2" equiv-text="&lt;Br /&gt;"/> breaks <x id="LINE_BREAK_1" equiv-text="&lt;BR/&gt;"/>.</source>
@@ -142,7 +127,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">40</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8048158107145255945" datatype="html">
         <source>09. <x id="START_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;em&gt;"/>We have nested interpolations and <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>a line<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> break<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> in-between<x id="CLOSE_EMPHASISED_TEXT" ctype="x-em" equiv-text="&lt;/em&gt;"/>.</source>
@@ -150,7 +134,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">42</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="1162418464075294573" datatype="html">
         <source>10. A line break <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br/&gt;"/> and all sorts <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> of <x id="HORIZONTAL_RULE" ctype="x-hr" equiv-text="&lt;hr/&gt;"/> horizontal <x id="HORIZONTAL_RULE_1" equiv-text="&lt;HR&gt;"/> rules,<x id="HORIZONTAL_RULE_2" equiv-text="&lt;hr style=&quot;display: none&quot;/&gt;"/> even with attributes.</source>
@@ -158,7 +141,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">44</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="9075420308171641266" datatype="html">
         <source>11. Symbols: &lt; &lt; &amp;&amp; &gt;&gt; &lt;1&gt;</source>
@@ -166,7 +148,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">46</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="7789534275794595013" datatype="html">
         <source>12. Variable interpolation: my name is <x id="INTERPOLATION" equiv-text="{{ name }}"/>.</source>
@@ -174,7 +155,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">48</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="5008943336610818013" datatype="html">
         <source>13. Named placeholder: <x id="ITEMCOUNT" equiv-text="{{ items.length // i18n(ph=&quot;itemCount&quot;) }}"/> items.</source>
@@ -182,7 +162,6 @@
           <context context-type="sourcefile">src/app/app.component.html</context>
           <context context-type="linenumber">50</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6962731021804310323" datatype="html">
         <source>Text to be translated</source>
@@ -190,7 +169,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">17</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="28113302887959640" datatype="html">
         <source>Hello <x id="PH" equiv-text="this.name"/>.</source>
@@ -198,7 +176,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">18</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="6983233377181567851" datatype="html">
         <source>You have two friends: <x id="PH" equiv-text="this.friendNames[0]"/> &amp; <x id="PH_1" equiv-text="this.friendNames[1]"/>.</source>
@@ -206,7 +183,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="8967721153468652541" datatype="html">
         <source>There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
@@ -214,7 +190,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">20</context>
         </context-group>
-        <target></target>
       </trans-unit>
       <trans-unit id="3663231730977935317" datatype="html">
         <source>Hello <x id="PH" equiv-text="this.name"/>. There are <x id="itemCount" equiv-text="this.items.length"/> items in your cart.</source>
@@ -222,7 +197,6 @@
           <context context-type="sourcefile">src/app/app.component.ts</context>
           <context context-type="linenumber">21</context>
         </context-group>
-        <target></target>
       </trans-unit>
     </body>
   </file>

--- a/src/calls/base.js
+++ b/src/calls/base.js
@@ -349,11 +349,7 @@ class Base {
       translatedTargetSegments.forEach(translatedTargetSegment => {
         let targetXmlUnit = targetXmlUnitsHash[this.uniqueIdentifier(translatedTargetSegment)]
 
-        if (targetXmlUnit) {
-          console.log("---")
-          console.log(translatedTargetSegment.source)
-          console.log(translatedTargetSegment.target)
-          console.log("---\n")
+        if (targetXmlUnit && translatedTargetSegment.target != '') { // if not translated, then no <target>, then fallback to source language
           targetXmlUnit.target = this.recomposeTarget(targetXmlUnit, translatedTargetSegment)
         }
       })

--- a/src/calls/base.js
+++ b/src/calls/base.js
@@ -350,7 +350,8 @@ class Base {
         let targetXmlUnit = targetXmlUnitsHash[this.uniqueIdentifier(translatedTargetSegment)]
 
         if (targetXmlUnit) {
-          console.log("---\n")
+          console.log("---")
+          console.log(translatedTargetSegment.source)
           console.log(translatedTargetSegment.target)
           console.log("---\n")
           targetXmlUnit.target = this.recomposeTarget(targetXmlUnit, translatedTargetSegment)

--- a/src/calls/base.js
+++ b/src/calls/base.js
@@ -350,6 +350,9 @@ class Base {
         let targetXmlUnit = targetXmlUnitsHash[this.uniqueIdentifier(translatedTargetSegment)]
 
         if (targetXmlUnit) {
+          console.log("---\n")
+          console.log(translatedTargetSegment.target)
+          console.log("---\n")
           targetXmlUnit.target = this.recomposeTarget(targetXmlUnit, translatedTargetSegment)
         }
       })
@@ -436,4 +439,3 @@ class Base {
 }
 
 module.exports = Base
-


### PR DESCRIPTION
It prevented the fallback to source language to work as intended.