### PR TITLE
Hotfix - Improve the rebuilding of target XLF files

### DIFF
--- a/src/calls/base.js
+++ b/src/calls/base.js
@@ -343,7 +343,8 @@ class Base {
       const targetXmlUnits = this.forceArray(targetXml.xliff.file.body['trans-unit']) // Ensure consistent array
 
       // 4 Populate the loaded .xlf it with targets from Translation.io
-      const translatedTargetSegmentsHash = this.buildTranslatedTargetSegmentsHash(response.segments[language])
+      const translatedTargetSegments     = response.segments[language]
+      const translatedTargetSegmentsHash = this.buildTranslatedTargetSegmentsHash(translatedTargetSegments)
 
       // Iterate over XML units
       targetXmlUnits.forEach(targetXmlUnit => {
@@ -362,6 +363,7 @@ class Base {
     })
   }
 
+  // For O(1) search optimization
   buildTranslatedTargetSegmentsHash(segments) {
     let translatedTargetSegmentsHash = {}
 


### PR DESCRIPTION
We rewrote the `writeTargetFiles` method in `base.js` to iterate on existing XML trans-units (based on the source XLF file) instead of iterating on the segments from the Translation.io response.

This ensures that all XML trans-units for which we compute the same `uniqueIdentifier` will be filled with the same target from the Translation.io response.

This fix is put in place after one of our users noticed that some XML trans-units were not filled with the target during a sync.
Indeed, the angular i18n-extractor creates two separate trans-units for sources that "seem" identical but are actually padded with spaces:
```
<p i18n>Example</p>

<div>
    <p i18n>
      Example
    </p>
</div>
```

Our package purposely trims any leading or trailing space when processing sources, so this results in only one segment being sent to Translation.io.